### PR TITLE
Fixed Markdown in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,9 @@ have to jump a couple of legal hurdles.
 Please fill out either the individual or corporate Contributor License Agreement (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA]
-    (https://cla.developers.google.com).
+    own the intellectual property, then you'll need to sign an [individual CLA](https://cla.developers.google.com).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA]
-    (https://cla.developers.google.com).
+    then you'll need to sign a [corporate CLA](https://cla.developers.google.com).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to
@@ -27,8 +25,7 @@ accept your pull requests.
 1. Fork the desired repo, develop and test your code changes.
 1. Ensure that your code adheres to the existing style in the sample to which
    you are contributing. Refer to the
-   [Android Code Style Guide]
-   (https://source.android.com/source/code-style.html) for the
+   [Android Code Style Guide](https://source.android.com/source/code-style.html) for the
    recommended coding standards for this organization.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,11 @@ have to jump a couple of legal hurdles.
 Please fill out either the individual or corporate Contributor License Agreement (CLA).
 
   * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA](https://cla.developers.google.com).
+    own the intellectual property, then you'll need to sign an 
+    [individual CLA](https://cla.developers.google.com).
   * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA](https://cla.developers.google.com).
+    then you'll need to sign a 
+    [corporate CLA](https://cla.developers.google.com).
 
 Follow either of the two links above to access the appropriate CLA and
 instructions for how to sign and return it. Once we receive it, we'll be able to

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Once you get a MediaProjection, use [createVirtualDisplay][4] and bind it to a S
 
 [1]: https://developer.android.com/reference/android/media/projection/MediaProjection.html
 [2]: https://developer.android.com/reference/android/media/projection/MediaProjectionManager.html#createScreenCaptureIntent()
-[3]: https://developer.android.com/reference/android/media/projection/MediaProjectionManager.html#getMediaProjection(int, android.content.Intent)
-[4]: https://developer.android.com/reference/android/media/projection/MediaProjection.html#createVirtualDisplay(java.lang.String, int, int, int, int, android.view.Surface, android.hardware.display.VirtualDisplay.Callback, android.os.Handler)
+[3]: https://developer.android.com/reference/android/media/projection/MediaProjectionManager.html#getMediaProjection%28int%2C+android.content.Intent%29
+[4]: https://developer.android.com/reference/android/media/projection/MediaProjection.html#createVirtualDisplay%28java.lang.String%2C+int%2C+int%2C+int%2C+int%2C+android.view.Surface%2C+android.hardware.display.VirtualDisplay.Callback%2C+android.os.Handler%29
 
 Pre-requisites
 --------------


### PR DESCRIPTION
Two of the URLs in README.md are not encoded properly and the URLs in CONTRIBUTING.md have syntax errors. It was bothering me so I fixed it. The relevant issue is #11. No unit tests needed.

Edit: Misread the style guide the first time around, just submitted a commit to fix line lengths in CONTRIBUTING.md.